### PR TITLE
added benchmark. closes lstrojny#15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
 script:
   - vendor/bin/phpunit --configuration phpunit-unit.xml.dist
   - vendor/bin/phpunit --configuration phpunit-integration.xml.dist
+  - vendor/bin/athletic --path tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark --bootstrap tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark/bootstrap.php --formatter GroupedFormatter
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "ext-sqlite3": "*"
     },
     "require-dev": {
-        "symfony/process": "2.*"
+        "symfony/process": "2.*",
+        "athletic/athletic": "~0.1"
     },
     "authors": [
         {

--- a/src/PHPUnit/Runner/CleverAndSmart/Storage/MockedStorage.php
+++ b/src/PHPUnit/Runner/CleverAndSmart/Storage/MockedStorage.php
@@ -1,0 +1,23 @@
+<?php
+namespace PHPUnit\Runner\CleverAndSmart\Storage;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Runner\CleverAndSmart\Run;
+
+class MockedStorage implements StorageInterface
+{
+    public function __construct()
+    {
+        // nothing todo
+    }
+
+    public function record(Run $run, TestCase $test, $time, $status)
+    {
+        // nothing todo
+    }
+
+    public function getRecordings(array $types, $includeTime = true)
+    {
+        return array();
+    }
+}

--- a/tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark/RunSuiteEvent.php
+++ b/tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark/RunSuiteEvent.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace PHPUnit\Tests\Runner\CleverAndSmart\Benchmark;
+
+use Athletic\AthleticEvent;
+use Symfony\Component\Process\Process;
+
+class RunSuiteEvent extends AthleticEvent
+{
+    private $sutRoot = 'vendor/symfony/yaml/Symfony/Component/Yaml/';
+    private $plainConfig = 'plain-phpunit.xml';
+    private $mockedConfig = 'mocked-phpunit.xml';
+    private $sqliteConfig = 'sqlite-phpunit.xml';
+    
+    public function classSetUp()
+    {
+        $org = $this->sutRoot . 'phpunit.xml.dist';
+        // plain config to run the suite as-is
+        copy($org, $this->plainConfig);
+        
+        $this->patchPhpunitConfig($this->sqliteConfig, 'PHPUnit\Runner\CleverAndSmart\Storage\Sqlite3Storage');
+        $this->patchPhpunitConfig($this->mockedConfig, 'PHPUnit\Runner\CleverAndSmart\Storage\MockedStorage');
+    }
+    
+    private function patchPhpunitConfig($patchedConfigFilename, $storageClass) {
+        $org = $this->sutRoot . 'phpunit.xml.dist';
+        
+        $testlistener = '
+        <listeners>
+            <listener class="PHPUnit\Runner\CleverAndSmart\TestListener">
+                <arguments>
+                    <object class="'. $storageClass .'"/>
+                </arguments>
+            </listener>
+        </listeners>';
+        
+        $content = file_get_contents($org);
+        $content = str_replace('<testsuites>', $testlistener. '<testsuites>', $content);
+        file_put_contents($patchedConfigFilename, $content);
+    }
+    
+    public function classTearDown()
+    {
+        unlink($this->plainConfig);
+        unlink($this->mockedConfig);
+        unlink($this->sqliteConfig);
+    }
+
+    /**
+     * @baseline
+     * @iterations 10
+     */
+    public function plainSuite()
+    {
+        $this->runSuite($this->plainConfig);
+    }
+    
+    /**
+     * @iterations 10
+     */
+    public function instrumentedMockedSuite()
+    {
+        $this->runSuite($this->mockedConfig);
+    }
+    
+    /**
+     * @iterations 10
+     */
+    public function instrumentedSqliteSuite()
+    {
+        $this->runSuite($this->sqliteConfig);
+    }
+    
+    private function runSuite($config) {
+        $cmd = 'phpunit --configuration '. $config .' '. $this->sutRoot;
+        
+        $process = new Process($cmd);
+        $process->run();
+        
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException($process->getErrorOutput());
+        }
+        
+        // no need to output the generated phpunit report on success.
+        // we are only interessted how long it took.
+    }
+}

--- a/tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark/bootstrap.php
+++ b/tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark/bootstrap.php
@@ -1,0 +1,22 @@
+<?php
+
+ini_set('error_reporting', E_ALL);
+
+// we assume the cwd is the project root
+$files = array('vendor/autoload.php');
+
+foreach ($files as $file) {
+    if (file_exists($file)) {
+        $loader = require $file;
+
+        break;
+    }
+}
+
+if (! isset($loader)) {
+    throw new RuntimeException('vendor/autoload.php could not be found. Did you run `php composer.phar install`?');
+}
+
+require 'tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark/RunSuiteEvent.php';
+
+unset($files, $file, $loader);


### PR DESCRIPTION
closes lstrojny#15

after some try&error I got the benchmark running on travis.

I used Symfony/Yaml as a references suite, so I don't need to introduce a big test-suite only for benchmarking which would slow down the CI build considerably.

ATM it seems we have an overhead of ~ 80%
