### PR TITLE
build against different phpunit versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,28 @@
 language: php
+
 php:
   - 5.3
   - 5.4
   - 5.5
   - hhvm
 
+env:
+  - PHPUNIT_VERSION="3.7.*"
+  - PHPUNIT_VERSION="3.8.*"
+  
+matrix:
+  allow_failures:
+    - php: hhvm
+    - env: PHPUNIT_VERSION="3.8.*"
+  exclude:
+    - php: 5.3
+      env: PHPUNIT_VERSION="3.8.*"
+
 before_script:
+  - composer require phpunit/phpunit=$PHPUNIT_VERSION
   - composer install
 
 script:
   - vendor/bin/phpunit --configuration phpunit-unit.xml.dist
   - vendor/bin/phpunit --configuration phpunit-integration.xml.dist
   - vendor/bin/athletic --path tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark --bootstrap tests/PHPUnit/Tests/Runner/CleverAndSmart/Benchmark/bootstrap.php --formatter GroupedFormatter
-
-matrix:
-  allow_failures:
-    - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "lstrojny/phpunit-clever-and-smart",
     "description": "A clever test runner for PHPUnit",
     "license": "MIT",
+    "minimum-stability": "dev",
     "require": {
         "phpunit/phpunit": "3.*",
         "ext-sqlite3": "*"


### PR DESCRIPTION
added phpunit 3.8 to the travis build matrix and allow it to fail (since it doesn't work right now).
I also tried 3.9 but it was also failing, therefore using only 3.8 for now.

php 5.3+phpunit 3.8 was excluded because the versions are not compatible.

closes https://github.com/lstrojny/phpunit-clever-and-smart/issues/23
