### PR TITLE
Fixed exit code

### DIFF
--- a/src/PHPUnit/Runner/CleverAndSmart/TestListener.php
+++ b/src/PHPUnit/Runner/CleverAndSmart/TestListener.php
@@ -129,6 +129,6 @@ class TestListener implements TestListenerInterface
 
         $this->storage->record($this->run, $this->currentTest, 0, StorageInterface::STATUS_CANCEL);
 
-        exit(255);
+        exit(1);
     }
 }


### PR DESCRIPTION
Exit code 255 is reserved for php internal use-cases. Per spec exit code 1 is ment for general errors.
